### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,18 +67,18 @@ and where.
    1) Windows: `python -m pip install -r requirements.txt`
    2) Linux/MacOS: `python -m pip install -r requirements.txt`
 6) Pull down the two needed datasets into the following folders within the project folder:
-   1) `wiki-dataset` folder: https://huggingface.co/datasets/NeuML/wikipedia-20240101
-       You would need git-lfs installed to clone it
-       Windows: https://git-lfs.com/
-       Mac: https://git-lfs.com/ or `brew install git-lfs`
-       Linux Ubuntu/Debian: `sudo apt install git-lfs`
-       Then run:
-         `git lfs install`
-         `git clone https://huggingface.co/datasets/NeuML/wikipedia-20240101`
-       The dataset requieres to be called `wiki-dataset` so rename it:
-         `mv wikipedia-20240101 wiki-dataset`      
+   1) `wiki-dataset` folder: https://huggingface.co/datasets/NeuML/wikipedia-20240101 
+        You would need git-lfs installed to clone it
+        Windows: https://git-lfs.com/
+        Mac: https://git-lfs.com/ or `brew install git-lfs`
+        Linux Ubuntu/Debian: `sudo apt install git-lfs`
+        Then run:
+        `git lfs install`
+        `git clone https://huggingface.co/datasets/NeuML/wikipedia-20240101`
+        The dataset requieres to be called `wiki-dataset` so rename it:
+        `mv wikipedia-20240101 wiki-dataset`      
    3) `txtai-wikipedia` folder: https://huggingface.co/NeuML/txtai-wikipedia
-       `git clone https://huggingface.co/NeuML/txtai-wikipedia`
+        `git clone https://huggingface.co/NeuML/txtai-wikipedia`
    5) See project structure below to make sure you did it right
 7) Run start_api.py
    1) Windows: python start_api.py

--- a/README.md
+++ b/README.md
@@ -53,20 +53,33 @@ and where.
 ### Manual Installation
 
 1) Pull down the code from https://github.com/SomeOddCodeGuy/OfflineWikipediaTextApi
+   `git clone https://github.com/SomeOddCodeGuy/OfflineWikipediaTextApi`
 2) Open command prompt and navigate to the folder containing the code
+   `cd OfflineWikipediaTextApi`
 3) Optional: create a python virtual environment.
    1) Windows: `python -m venv venv`
    2) MacOS/Linux: `python3 -m venv venv`
 4) Optional: activate python virtual environment.
    1) Windows: `venv\Scripts\activate`
    2) MacOS/Linux: `venv/bin/activate`
+   3) Fish shell: `venv/bin/activate.fish`
 5) Pip install the requirements from requirements.txt
    1) Windows: `python -m pip install -r requirements.txt`
-   2) Linux/MacOS: `python3 -m pip install -r requirements.txt`
+   2) Linux/MacOS: `python -m pip install -r requirements.txt`
 6) Pull down the two needed datasets into the following folders within the project folder:
    1) `wiki-dataset` folder: https://huggingface.co/datasets/NeuML/wikipedia-20240101
-   2) `txtai-wikipedia` folder: https://huggingface.co/NeuML/txtai-wikipedia
-   3) See project structure below to make sure you did it right
+       You would need git-lfs installed to clone it
+       Windows: https://git-lfs.com/
+       Mac: https://git-lfs.com/ or `brew install git-lfs`
+       Linux Ubuntu/Debian: `sudo apt install git-lfs`
+       Then run:
+         `git lfs install`
+         `git clone https://huggingface.co/datasets/NeuML/wikipedia-20240101`
+       The dataset requieres to be called `wiki-dataset` so rename it:
+         `mv wikipedia-20240101 wiki-dataset`      
+   3) `txtai-wikipedia` folder: https://huggingface.co/NeuML/txtai-wikipedia
+       `git clone https://huggingface.co/NeuML/txtai-wikipedia`
+   5) See project structure below to make sure you did it right
 7) Run start_api.py
    1) Windows: python start_api.py
    2) MacOS/Linux: python3 start_api.py


### PR DESCRIPTION
Added git clone commands to make it more guided

Added `cd`commands to change directory

Changed `python3` to `python`in linux as inside the venv python3 is not recognized 

Added fish shell activate script

Added information on how to install and download the datasets using git lfs

Added clarification on the naming requiered for the wiki dataset