### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ fastapi~=0.115.5
 datasets~=3.1.0
 txtai~=7.5.1
 colorama~=0.4.6
+numpy<2.0.0


### PR DESCRIPTION
numpy 2+ causes issues on macOS.

Before the fix:
```
Traceback (most recent call last):  File "/Users/seven/Documents/projects/ai/OfflineWikipediaTextApi/start_api.py", line 11, in <module>
    from txtai.embeddings import Embeddings
  File "/Users/seven/Documents/projects/ai/OfflineWikipediaTextApi/venv/lib/python3.12/site-packages/txtai/__init__.py", line 8, in <module>
    from .app import Application
  File "/Users/seven/Documents/projects/ai/OfflineWikipediaTextApi/venv/lib/python3.12/site-packages/txtai/app/__init__.py", line 5, in <module>
    from .base import Application, ReadOnlyError
  File "/Users/seven/Documents/projects/ai/OfflineWikipediaTextApi/venv/lib/python3.12/site-packages/txtai/app/base.py", line 12, in <module>
    from ..embeddings import Documents, Embeddings
  File "/Users/seven/Documents/projects/ai/OfflineWikipediaTextApi/venv/lib/python3.12/site-packages/txtai/embeddings/__init__.py", line 5, in <module>
    from .base import Embeddings
  File "/Users/seven/Documents/projects/ai/OfflineWikipediaTextApi/venv/lib/python3.12/site-packages/txtai/embeddings/base.py", line 12, in <module>
    from ..ann import ANNFactory
  File "/Users/seven/Documents/projects/ai/OfflineWikipediaTextApi/venv/lib/python3.12/site-packages/txtai/ann/__init__.py", line 7, in <module>
    from .factory import ANNFactory
  File "/Users/seven/Documents/projects/ai/OfflineWikipediaTextApi/venv/lib/python3.12/site-packages/txtai/ann/factory.py", line 13, in <module>
    from .torch import Torch
  File "/Users/seven/Documents/projects/ai/OfflineWikipediaTextApi/venv/lib/python3.12/site-packages/txtai/ann/torch.py", line 6, in <module>
    import torch
  File "/Users/seven/Documents/projects/ai/OfflineWikipediaTextApi/venv/lib/python3.12/site-packages/torch/__init__.py", line 1477, in <module>
    from .functional import *  # noqa: F403
  File "/Users/seven/Documents/projects/ai/OfflineWikipediaTextApi/venv/lib/python3.12/site-packages/torch/functional.py", line 9, in <module>
    import torch.nn.functional as F
  File "/Users/seven/Documents/projects/ai/OfflineWikipediaTextApi/venv/lib/python3.12/site-packages/torch/nn/__init__.py", line 1, in <module>
    from .modules import *  # noqa: F403
  File "/Users/seven/Documents/projects/ai/OfflineWikipediaTextApi/venv/lib/python3.12/site-packages/torch/nn/modules/__init__.py", line 35, in <module>
    from .transformer import TransformerEncoder, TransformerDecoder, \
  File "/Users/seven/Documents/projects/ai/OfflineWikipediaTextApi/venv/lib/python3.12/site-packages/torch/nn/modules/transformer.py", line 20, in <module>
    device: torch.device = torch.device(torch._C._get_default_device()),  # torch.device('cpu'),
/Users/seven/Documents/projects/ai/OfflineWikipediaTextApi/venv/lib/python3.12/site-packages/torch/nn/modules/transformer.py:20: UserWarning: Failed to initialize NumPy: _ARRAY_API not found (Triggered internally at /Users/runner/work/pytorch/pytorch/pytorch/torch/csrc/utils/tensor_numpy.cpp:84.)
  device: torch.device = torch.device(torch._C._get_default_device()),  # torch.device('cpu'),

```
After the fix:

```
Requirement already satisfied: mpmath<1.4,>=1.1.0 in ./venv/lib/python3.12/site-packages (from sympy->torch>=1.12.1->txtai~=7.5.1->-r requirements.txt (line 5)) (1.3.0)
Using cached numpy-1.26.4-cp312-cp312-macosx_10_9_x86_64.whl (20.3 MB)
Installing collected packages: numpy
  Attempting uninstall: numpy
    Found existing installation: numpy 2.2.4
    Uninstalling numpy-2.2.4:
      Successfully uninstalled numpy-2.2.4
Successfully installed numpy-1.26.4

[notice] A new release of pip is available: 24.2 -> 25.0.1
[notice] To update, run: pip install --upgrade pip
---------------------------------------------------------------
Downloading Wikipedia dataset. As of 2024-11-14, this is about 44GB
Existing wiki-dataset directory detected.
---------------------------------------------------------------
Downloading txtai-wikipedia dataset. As of 2024-11-14, this is about 15GB.
Existing txtai-wikipedia directory detected.
---------------------------------------------------------------
Starting API. If this is the first run, setup may take 10-15 minutes depending on your machine.
Setup time is due to indexing wikipedia article titles into a json file for API speed.
---------------------------------------------------------------
API Starting...

```