### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ datasets~=3.1.0
 txtai~=7.5.1
 colorama~=0.4.6
 numpy<2.0.0
+transformers~=4.46.2


### PR DESCRIPTION
Locking transformers to a known good version for the time being. Ran into an issue on a new Mac where transformers was loading a version that was throwing fits with txtai; until I can sort out what it is, I know 4.46.2/4.46.3 work, so pinning to this for now