### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-uvicorn~=0.32.0
-fastapi~=0.115.5
-datasets~=3.1.0
-txtai~=7.5.1
+uvicorn~=0.34.0
+fastapi~=0.115.12
+datasets~=3.5.0
+txtai~=8.4.0
 colorama~=0.4.6
 numpy<2.0.0
-transformers~=4.46.2
+accelerate~=1.6.0


### PR DESCRIPTION
Dependabot scolded me for the older version of transformers, so went ahead and updated all of the dependencies. Also, added accelerate, which should solve the problem I ran into with versions of transformers > 4.48 where you get the error `NameError: name 'init_empty_weights' is not defined`

Tested this on both Windows and MacOS.