### PR TITLE
Rolling back torch to 2.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ txtai~=8.6.0
 colorama~=0.4.6
 numpy~=2.3.1
 accelerate~=1.8.1
+torch~=2.7.0


### PR DESCRIPTION
Torch 2.8.0 appears to have an issue for Mac users that are causing the results to be all kinds of messed up. Rolling back to 2.7.0 corrects this issue. Rolling back for now to correct the issue